### PR TITLE
Publish Release Workflow

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -13,7 +13,9 @@ jobs:
   preview:
 
     runs-on: ubuntu-latest
-    environment: "Publish Release"
+    environment: 
+      name: "Publish Release"
+
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to NuGet
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+    environment: 
+      name: "Publish Release"
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore Dependencies
+      run: dotnet restore src
+    - name: Build
+      run: dotnet build src --configuration Release --no-restore
+    - name: Publish NuGet
+      uses: brandedoutcast/publish-nuget@v2.5.5
+      with:
+        PROJECT_FILE_PATH: src/Wayfair.Text.Json/Wayfair.Text.Json.csproj
+        NUGET_KEY: ${{secrets.NUGET_API_KEY}}


### PR DESCRIPTION
## Description

This puts in a place a workflow that publishes a release of the library, using the version from the project file, on merge into main, if the version of the project does not already exist in NuGet.

This also swaps to specifying the environment name specifically, for both the publish preview and publish release workflows.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe) - publishing of the library

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/wayfair-text-json/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
