### PR TITLE
Update README version badge to match latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WaySON
 
-[![WaySON Version](https://img.shields.io/badge/WaySON-0.1.0-7f187f.svg)](https://github.com/wayfair-incubator/wayfair-text-json/blob/main/CHANGELOG.md)
+[![WaySON Version](https://img.shields.io/badge/WaySON-1.0.0-7f187f.svg)](https://github.com/wayfair-incubator/wayfair-text-json/blob/main/CHANGELOG.md)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![.NET Build & Test](https://github.com/wayfair-incubator/wayfair-text-json/actions/workflows/build-and-test.yml/badge.svg?branch=main)](https://github.com/wayfair-incubator/wayfair-text-json/actions/workflows/build-and-test.yml)
 [![Lint Markdown files](https://github.com/wayfair-incubator/wayfair-text-json/actions/workflows/markdown-lint.yml/badge.svg?branch=main)](https://github.com/wayfair-incubator/wayfair-text-json/actions/workflows/markdown-lint.yml)


### PR DESCRIPTION
## Description

Version 1.0.0 was just released, but README displays a badge for 0.1.0

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/wayfair-text-json/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
